### PR TITLE
refa: move logger config to Base.__init__

### DIFF
--- a/python-package/basedosdados/constants.py
+++ b/python-package/basedosdados/constants.py
@@ -10,12 +10,6 @@ class config:
     billing_project_id: str = None
     project_config_path: str = None
 
-    def __new__(self):
-        logger.remove(0) # remove o default handler
-        logger_level = 'INFO' if self.verbose else 'ERROR'
-        logger.add(sys.stderr, format="<level>{message}</level>", level=logger_level)
-
-
 class constants(Enum):
     ENV_CONFIG: str = "BASEDOSDADOS_CONFIG"
     ENV_CREDENTIALS_PREFIX: str = "BASEDOSDADOS_CREDENTIALS_"

--- a/python-package/basedosdados/upload/base.py
+++ b/python-package/basedosdados/upload/base.py
@@ -29,6 +29,7 @@ class Base:
         self.config_path = Path.home() / config_path
         self._init_config(force=overwrite_cli_config)
         self.config = self._load_config()
+        self._config_log(constants.config.verbose)
 
         self.templates = Path(templates or self.config["templates_path"])
         self.metadata_path = Path(metadata_path or self.config["metadata_path"])
@@ -294,6 +295,13 @@ class Base:
             c_file["templates_path"] = str(Path.home() / ".basedosdados" / "templates")
 
             config_file.open("w", encoding="utf-8").write(tomlkit.dumps(c_file))
+
+
+    def _config_log(self, verbose: bool):
+        logger.remove(0) # remove o default handler
+        logger_level = 'INFO' if verbose else 'ERROR'
+        logger.add(sys.stderr, format="<level>{message}</level>", level=logger_level)
+
 
     def _load_config(self):
 

--- a/python-package/basedosdados/upload/table.py
+++ b/python-package/basedosdados/upload/table.py
@@ -22,7 +22,6 @@ from basedosdados.upload.dataset import Dataset
 from basedosdados.upload.datatypes import Datatype
 from basedosdados.upload.metadata import Metadata
 from basedosdados.exceptions import BaseDosDadosException
-from basedosdados.constants import config
 
 
 class Table(Base):


### PR DESCRIPTION
Movendo o codigo que faz a configuração do logger
Deixando ele mais explicito e removendo o problema de ter que instanciar o config